### PR TITLE
Updates to logging

### DIFF
--- a/jailer.py
+++ b/jailer.py
@@ -1,4 +1,5 @@
 import logging
+import logging.handlers
 import interactions
 from interactions import listen, Intents, Permissions, slash_default_member_permission
 from interactions.api.events import Ready
@@ -8,12 +9,33 @@ from pytimeparse.timeparse import timeparse
 import datetime
 import asyncio # not currently in use but might later
 
-logging.basicConfig()
+if not os.path.exists("logs"):
+    os.makedirs("logs")
+
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+fileHandler = logging.handlers.TimedRotatingFileHandler(
+    filename="logs/jailer.log", 
+    when="midnight",
+    backupCount=28, 
+    encoding="utf-8")
+fileHandler.setFormatter(formatter)
+fileHandler.setLevel(logging.DEBUG)
+
+streamHandler = logging.StreamHandler()
+streamHandler.setLevel(logging.INFO)
+streamHandler.setFormatter(formatter)
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers= [fileHandler, streamHandler],
+    level=logging.DEBUG
+)
+
 cls_log = logging.getLogger("JailerLogger")
-cls_log.setLevel(logging.DEBUG)
 
 bot = interactions.Client(
-    intents=Intents.ALL,
+    intents=Intents.ALL,    
     token=os.environ["DISCORD_TOKEN"],
     default_scope=os.environ["GUILD_ID"],
     sync_interactions=True,

--- a/jailer.py
+++ b/jailer.py
@@ -27,9 +27,9 @@ users = []
 # functions
 def parse_duration(duration: str) -> datetime.timedelta:
     duration = duration.lower()
-    print(f'Parsing duration {duration}')
+    cls_log.debug(f'Parsing duration {duration}')
     seconds = timeparse(duration)
-    print(f'Parsed duration {duration} seconds')
+    cls_log.debug(f'Parsed duration {duration} seconds')
     return datetime.datetime.now() + datetime.timedelta(seconds=seconds)
     
 def jail_user(user: str, duration: datetime.timedelta, annoy: bool = False):
@@ -40,7 +40,7 @@ def jail_user(user: str, duration: datetime.timedelta, annoy: bool = False):
         "start_time": datetime.datetime.now(),
         "annoyed_last": datetime.datetime.now()
     })
-    print(users)
+    cls_log.info(users)
 
 def release_user(user: interactions.User):
     for u in users:
@@ -58,7 +58,7 @@ def list_users():
 
 @interactions.listen()
 async def on_startup():
-    print("Bot is ready")
+    cls_log.info("Bot is ready")
     check_jail.start()
 
 @interactions.Task.create(interactions.IntervalTrigger(seconds=5))
@@ -78,9 +78,9 @@ async def check_jail():
 @interactions.slash_option(name="annoy", description="Annoy the user", opt_type=interactions.OptionType.BOOLEAN, required=False)
 async def jail(ctx: interactions.SlashContext, user: str, duration: str, annoy: bool = False):
     duration = parse_duration(duration)
-    print(f'Jailing {user} for {duration} with annoy={annoy}')
+    cls_log.info(f'Jailing {user} for {duration} with annoy={annoy}')
     jail_user(user, duration, annoy)
-    print(f'Error jailing user: {user}')
+    cls_log.error(f'Error jailing user: {user}')
     await interactions.Member.timeout(user, duration)
     await ctx.send(f'Jailing {user} for {duration} with annoy={annoy}')
 
@@ -88,7 +88,7 @@ async def jail(ctx: interactions.SlashContext, user: str, duration: str, annoy: 
 @interactions.slash_default_member_permission(Permissions.MANAGE_CHANNELS)
 @interactions.slash_option(name="user", description="The user to jail", opt_type=interactions.OptionType.USER, required=True)
 async def release(ctx: interactions.SlashContext, user: interactions.User):
-    print(f'Releasing {user}')
+    cls_log.info(f'Releasing {user}')
     release_user(user)
     await interactions.Member.timeout(user, None)
     await ctx.send(f'Releasing {user}')
@@ -96,7 +96,7 @@ async def release(ctx: interactions.SlashContext, user: interactions.User):
 @interactions.slash_command(name="list", description="List all users in jail")
 @interactions.slash_default_member_permission(Permissions.MANAGE_CHANNELS)
 async def list(ctx: interactions.SlashContext):
-    print(f'Listing users in jail')
+    cls_log.info(f'Listing users in jail')
     users = list_users()
     if len(users) == 0:
         await ctx.send("No users in jail")


### PR DESCRIPTION
As the title says, these are some updates to logging as discussed when testing the bot earlier.

### Changes

- [x] - Bot now logs to file
- [x] - Log folder creation if not present
- [x] - Logs formatted on both handlers
- [x] - File logging backups and limits
- [x] - `Prints()` to STDOUT now replaced with most relevant log level and output

### Notes
- The console logging is now handled by the `streamHandler` this was needed so you can configure the log level of each handler.
- Currently the File Handler will log everything (DEBUG) and the Stream Handler will log INFO and above. Cuts down on verbose output in the Console while still keeping the major log info in a file if needed.
    - These log levels can be made environment variables if required, might make for easier management to be able to swap between log levels in file/console as needed.
- File logs are automatically "backed up" in the sense that at midnight the bot will save the current days log file with the name `jailer.log.timestamp`, then continue logging the new day with a fresh `jailer.log` file. 
- The logs are backed up for a maximum of 28days, after which it will start to replace the oldest log upon each backup.

### Example Output
#### Console
![console](https://github.com/user-attachments/assets/519c1199-1b6a-4832-b360-ccebd8f586a6)
#### File
![file](https://github.com/user-attachments/assets/74e6e08b-7a4a-4bfe-a718-8984b694eb56)
